### PR TITLE
fixes for passing the test suite

### DIFF
--- a/src/shpub/Cli.php
+++ b/src/shpub/Cli.php
@@ -24,7 +24,8 @@ class Cli
                     $res->command->args['server'],
                     $res->command->args['user'],
                     $res->command->args['key'],
-                    $res->command->options['force']
+                    $res->command->options['force'],
+                    $res->command->options['scope']
                 );
                 break;
 

--- a/src/shpub/Command/Connect.php
+++ b/src/shpub/Command/Connect.php
@@ -126,6 +126,7 @@ class Command_Connect
         $req->setBody(
             http_build_query(
                 [
+                    'grant_type'   => 'authorization_code',
                     'me'           => $userUrl,
                     'code'         => $code,
                     'redirect_uri' => $redirect_uri,
@@ -141,11 +142,14 @@ class Command_Connect
             Log::err($res->getBody());
             exit(2);
         }
-        if ($res->getHeader('content-type') != 'application/x-www-form-urlencoded') {
+        if ($res->getHeader('content-type') == 'application/x-www-form-urlencoded') {
+            parse_str($res->getBody(), $tokenParams);
+        } elseif ($res->getHeader('content-type') == 'application/json') {
+            $tokenParams = json_decode($res->getBody(), true);
+        } else {
             Log::err('Wrong content type in auth verification response');
             exit(2);
         }
-        parse_str($res->getBody(), $tokenParams);
         if (!isset($tokenParams['access_token'])) {
             Log::err('"access_token" missing');
             exit(2);

--- a/src/shpub/Command/Connect.php
+++ b/src/shpub/Command/Connect.php
@@ -28,6 +28,16 @@ class Command_Connect
                 'default'     => false,
             )
         );
+        $cmd->addOption(
+            'scope',
+            array(
+                'short_name'  => '-s',
+                'long_name'   => '--scope',
+                'description' => 'Space-separated list of scopes to request (default create)',
+                'action'      => 'StoreString',
+                'default'     => 'create',
+            )
+        );
         $cmd->addArgument(
             'server',
             [
@@ -51,7 +61,7 @@ class Command_Connect
         );
     }
 
-    public function run($server, $user, $newKey, $force)
+    public function run($server, $user, $newKey, $force, $scope)
     {
         $server = Validator::url($server, 'server');
         if ($user === null) {
@@ -75,7 +85,7 @@ class Command_Connect
         $state = time();
         Log::msg(
             "To authenticate, open the following URL:\n"
-            . $this->getBrowserAuthUrl($host, $user, $redirect_uri, $state)
+            . $this->getBrowserAuthUrl($host, $user, $redirect_uri, $state, $scope)
         );
 
         $authParams = $this->startHttpServer($socketStr);
@@ -159,14 +169,14 @@ class Command_Connect
         return $accessToken;
     }
 
-    protected function getBrowserAuthUrl($host, $user, $redirect_uri, $state)
+    protected function getBrowserAuthUrl($host, $user, $redirect_uri, $state, $scope)
     {
         return $host->endpoints->authorization
             . '?me=' . urlencode($user)
             . '&client_id=' . urlencode(static::$client_id)
             . '&redirect_uri=' . urlencode($redirect_uri)
             . '&state=' . $state
-            . '&scope=post'
+            . '&scope=' . urlencode($scope)
             . '&response_type=code';
     }
 

--- a/src/shpub/Command/Rsvp.php
+++ b/src/shpub/Command/Rsvp.php
@@ -49,7 +49,7 @@ class Command_Rsvp extends Command_AbstractProps
         }
 
         $req = new Request($this->cfg->host, $this->cfg);
-        $req->setType('h', 'entry');
+        $req->setType('entry');
         $req->addProperty('in-reply-to', $url);
         $req->addProperty('rsvp', $rsvp);
         if ($cmdRes->args['text']) {

--- a/src/shpub/Request.php
+++ b/src/shpub/Request.php
@@ -56,7 +56,7 @@ class Request
                 $data['url'] = $this->url;
             }
             if ($this->type !== null) {
-                $data['type'] = 'h-' . $this->type;
+                $data['type'] = array('h-' . $this->type);
             }
             if (count($this->properties)) {
                 $data['properties'] = $this->properties;

--- a/src/shpub/Request.php
+++ b/src/shpub/Request.php
@@ -148,7 +148,13 @@ class Request
      */
     public function addUpload($fieldName, $fileNames)
     {
-        if ($this->host->endpoints->media === null
+        if($this->directUpload && $this->sendAsJson) {
+            throw new \Exception(
+                'Cannot do direct upload with JSON requests'
+            );
+        }
+
+        if ($this->host->endpoints->media == null
             || $this->directUpload
         ) {
             if ($this->sendAsJson) {


### PR DESCRIPTION
* sends `grant_type` parameter for code exchange
* accepts both form-encoded and json responses from token endpoint
* adds a parameter `scope` to request specific scope when connecting a new server
* sends type as array for JSON requests
* fixes RSVP types