### PR TITLE
Fix: issue when Content-Type for targets response contains charset

### DIFF
--- a/src/shpub/Command/Targets.php
+++ b/src/shpub/Command/Targets.php
@@ -29,7 +29,11 @@ class Command_Targets
         $req->req->getUrl()->setQueryVariable('q', 'syndicate-to');
         $res = $req->send();
 
-        if ($res->getHeader('content-type') != 'application/json') {
+        $contentTypeIsJson = strpos(
+            $res->getHeader('content-type'), 'application/json'
+        ) !== false;
+
+        if (!$contentTypeIsJson) {
             Log::err('response data are not of type application/json');
             exit(2);
         }


### PR DESCRIPTION
When running

    ./bin/shpub.php targets

against a Wordpress micropub provided by the [Micropub plugin](https://github.com/snarfed/wordpress-micropub), I get the following error:

> response data are not of type application/json

which is because the Content-Type header contains the charset as follows:

> Content-Type: application/json; charset=UTF-8

Because the code is expecting the Content-Type header to be *exactly* `application/json`, the conditional checking that it is json fails.

This can be resolved by making the check a bit looser, to check only that the content-type header *contains* `application/json`.

(Technically speaking, a JSON response should only have `application/json` in the content-type header, but it seems that quite a few servers return it with a charset, and that various applications expect.  See e.g. https://stackoverflow.com/a/19815111.  So it seems best to have a looser check.)