### PR TITLE
Force a reload of endpoints after obtaining token

### DIFF
--- a/src/shpub/Command/Connect.php
+++ b/src/shpub/Command/Connect.php
@@ -110,6 +110,9 @@ class Command_Connect
         $host->user  = $userUrl;
         $host->token = $accessToken;
 
+        // Now that the token is available, check for a media endpoint
+        $host->loadEndpoints(true);
+
         if ($newKey != '') {
             $hostKey = $newKey;
         } else {

--- a/src/shpub/Config/Host.php
+++ b/src/shpub/Config/Host.php
@@ -43,11 +43,11 @@ class Config_Host
         $this->endpoints = new Config_Endpoints();
     }
 
-    public function loadEndpoints()
+    public function loadEndpoints($forceReload = false)
     {
         $this->endpoints = new Config_Endpoints();
         $this->endpoints->load($this->server);
-        if ($this->endpoints->incomplete()) {
+        if ($this->endpoints->incomplete() || $forceReload) {
             $this->endpoints->discover($this->server);
             if ($this->token) {
                 $this->endpoints->discoverMedia($this->token);


### PR DESCRIPTION
Endpoints are loaded and cached prior to obtaining a token. Media endpoint is searched for unless a token is present. Subsequent endpoint loads do not attempt to discover the media endpoint because it is not included in the Incomplete check.